### PR TITLE
.gitignore and deletion of Daybreak Copywritten material from Daybreak Games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+spells_us.txt


### PR DESCRIPTION
Preferred is a tool that locally uses this file in the EverQuest installation folder instead of the file